### PR TITLE
SHLF-11: Setup OAS in Article Service

### DIFF
--- a/apps/article-service/build.gradle
+++ b/apps/article-service/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '4.0.3'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.openapi.generator' version "7.21.0"
 }
 
 group = 'org.shelfio'
@@ -27,6 +28,25 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+openApiGenerate {
+    generatorName = "spring"
+    inputSpec = file("${projectDir}/src/main/resources/openapi.yml").absolutePath
+    outputDir = layout.buildDirectory.dir("generated/openapi").get().asFile.absolutePath
+    apiPackage = "org.shelfio.article.api"
+    modelPackage = "org.shelfio.article.model"
+
+    configOptions = [
+            library              : "spring-boot",
+            interfaceOnly        : "true",
+            useTags              : "true",
+            useBeanValidation    : "true",
+            performBeanValidation: "true",
+            useJakartaEe         : "true",
+            dateLibrary          : "java8",
+            serializableModel    : "true"
+    ]
 }
 
 tasks.named('test') {

--- a/apps/article-service/build.gradle
+++ b/apps/article-service/build.gradle
@@ -24,6 +24,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 
+    implementation 'io.swagger.core.v3:swagger-annotations:2.2.46'
+    implementation 'jakarta.validation:jakarta.validation-api:3.1.1'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-security-oauth2-resource-server-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
@@ -41,8 +45,6 @@ openApiGenerate {
             library              : "spring-boot",
             interfaceOnly        : "true",
             useTags              : "true",
-            useBeanValidation    : "true",
-            performBeanValidation: "true",
             useJakartaEe         : "true",
             dateLibrary          : "java8",
             serializableModel    : "true"
@@ -51,4 +53,16 @@ openApiGenerate {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir layout.buildDirectory.dir("generated/openapi/src/main/java")
+        }
+    }
+}
+
+tasks.named('compileJava') {
+    dependsOn tasks.named('openApiGenerate')
 }

--- a/apps/article-service/src/main/resources/openapi.yml
+++ b/apps/article-service/src/main/resources/openapi.yml
@@ -9,6 +9,9 @@ servers:
   - url: http://localhost:8081/api/v1/
     description: Local development server
 
+security:
+  - bearerAuth: [ ]
+
 paths:
   "/groups":
     post:
@@ -36,7 +39,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '500':
-          description: Int server error
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -57,7 +60,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/GroupPreviewResponse'
         '500':
-          description: Int server error
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -97,7 +100,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '500':
-          description: Int server error
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -142,7 +145,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '500':
-          description: Int server error
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -175,7 +178,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '500':
-          description: Int server error
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -196,7 +199,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/ArticlePreviewResponse'
         '500':
-          description: Int server error
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -236,7 +239,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '500':
-          description: Int server error
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -281,7 +284,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '500':
-          description: Int server error
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -289,6 +292,12 @@ paths:
 
 
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
   schemas:
     ### --------- COMMON SCHEMAS --------- ###
     ErrorResponse:
@@ -517,8 +526,7 @@ components:
           type: string
           description: The new URI of the article
         groupId:
-          type:
-            - integer
+          type: integer
           format: int64
           description: The new group ID to which the article should belong
           nullable: true

--- a/apps/article-service/src/main/resources/openapi.yml
+++ b/apps/article-service/src/main/resources/openapi.yml
@@ -1,0 +1,532 @@
+openapi: 3.1.0
+
+info:
+  title: Article API
+  description: Provides basic operations to manage articles and groups
+  version: 0.0.1
+
+servers:
+  - url: http://localhost:8081/api/v1/
+    description: Local development server
+
+paths:
+  "/groups":
+    post:
+      summary: Create a new group
+      description: Creates a new group with the provided name
+      tags:
+        - group
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupCreateRequest'
+      responses:
+        '201':
+          description: Group created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupCreateResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Int server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    get:
+      summary: Get all groups
+      description: Retrieves a list of all groups with their IDs and names
+      tags:
+        - group
+      responses:
+        '200':
+          description: A list of groups retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GroupPreviewResponse'
+        '500':
+          description: Int server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  "/groups/{groupId}":
+    get:
+      summary: Get group details
+      description: Retrieves detailed information about a specific group, including its articles
+      tags:
+        - group
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+          description: The unique identifier of the group to retrieve
+      responses:
+        '200':
+          description: Group details retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupDetailResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Group not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Int server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    put:
+      summary: Update group details
+      description: Updates the name and associated articles of a specific group
+      tags:
+        - group
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+          description: The unique identifier of the group to update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateGroupRequest'
+      responses:
+        '200':
+          description: Group updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupDetailResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Group not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Int server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+
+  "/articles":
+    post:
+      summary: Create a new article
+      description: Creates a new article with the provided name, URI, and optional group ID
+      tags:
+        - article
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ArticleCreateRequest'
+      responses:
+        '201':
+          description: Article created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArticleCreateResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Int server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    get:
+      summary: Get all articles
+      description: Retrieves a list of all articles with their IDs, names, URIs, and group information
+      tags:
+        - article
+      responses:
+        '200':
+          description: A list of articles retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ArticlePreviewResponse'
+        '500':
+          description: Int server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  "/articles/{articleId}":
+    get:
+      summary: Get article details
+      description: Retrieves detailed information about a specific article, including its group information and notes
+      tags:
+        - article
+      parameters:
+        - name: articleId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+          description: The unique identifier of the article to retrieve
+      responses:
+        '200':
+          description: Article details retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArticleDetailResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Article not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Int server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    put:
+      summary: Update article details
+      description: Updates the name, URI, group association, and notes of a specific article
+      tags:
+        - article
+      parameters:
+        - name: articleId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+          description: The unique identifier of the article to update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateArticleRequest'
+      responses:
+        '200':
+          description: Article updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArticleDetailResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Article not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Int server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+
+components:
+  schemas:
+    ### --------- COMMON SCHEMAS --------- ###
+    ErrorResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          description: A descriptive error message
+      required:
+        - message
+
+    ### --------- GROUP SCHEMAS --------- ###
+    GroupCreateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the group
+      required:
+        - name
+
+    GroupCreateResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: The unique identifier of the created group
+        name:
+          type: string
+          description: The name of the created group
+      required:
+        - id
+        - name
+
+    GroupPreviewResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: The unique identifier of the group
+        name:
+          type: string
+          description: The name of the group
+      required:
+        - id
+        - name
+
+    GroupDetailResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: The unique identifier of the group
+        name:
+          type: string
+          description: The name of the group
+        createdAt:
+          type: string
+          format: date-time
+          description: The timestamp when the group was created
+        modifiedAt:
+          type: string
+          format: date-time
+          description: The timestamp when the group was last modified
+        articles:
+          type: array
+          items:
+            $ref: '#/components/schemas/ArticlePreviewResponse'
+      required:
+        - id
+        - name
+        - createdAt
+        - modifiedAt
+        - articles
+
+    UpdateGroupRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The new name of the group
+        articleIds:
+          type: array
+          items:
+            type: integer
+            format: int64
+          description: A list of article IDs to be associated with the group
+      required:
+        - name
+        - articleIds
+
+    ### --------- ARTICLE SCHEMAS --------- ###
+    ArticleCreateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the article
+        uri:
+          type: string
+          description: The URI of the article
+        groupId:
+          type: integer
+          format: int64
+          nullable: true
+      required:
+        - name
+        - uri
+        - groupId
+
+    ArticleCreateResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: The unique identifier of the created article
+        name:
+          type: string
+          description: The name of the created article
+        uri:
+          type: string
+          description: The URI of the created article
+        groupId:
+          type: integer
+          format: int64
+          description: The ID of the group to which the article belongs
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+          description: The timestamp when the article was created
+        modifiedAt:
+          type: string
+          format: date-time
+          description: The timestamp when the article was last modified
+      required:
+        - id
+        - name
+        - uri
+        - createdAt
+        - modifiedAt
+
+    ArticlePreviewResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: The unique identifier of the article
+        name:
+          type: string
+          description: The name of the article
+        uri:
+          type: string
+          description: The URI of the article
+        groupId:
+          type: integer
+          format: int64
+          description: The ID of the group to which the article belongs
+          nullable: true
+        groupName:
+          type: string
+          description: The name of the group to which the article belongs
+          nullable: true
+      required:
+        - id
+        - name
+        - uri
+        - groupId
+        - groupName
+
+    ArticleDetailResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: The unique identifier of the article
+        name:
+          type: string
+          description: The name of the article
+        uri:
+          type: string
+          description: The URI of the article
+        groupId:
+          type: integer
+          format: int64
+          description: The ID of the group to which the article belongs
+          nullable: true
+        groupName:
+          type: string
+          description: The name of the group to which the article belongs
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+          description: The timestamp when the article was created
+        modifiedAt:
+          type: string
+          format: date-time
+          description: The timestamp when the article was last modified
+        notes:
+          type: string
+          description: Additional notes or comments about the article (in future will support markdown formatting)
+      required:
+        - id
+        - name
+        - uri
+        - groupId
+        - groupName
+        - createdAt
+        - modifiedAt
+        - notes
+
+    UpdateArticleRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The new name of the article
+        uri:
+          type: string
+          description: The new URI of the article
+        groupId:
+          type:
+            - integer
+          format: int64
+          description: The new group ID to which the article should belong
+          nullable: true
+        notes:
+          type: string
+          description: Additional notes or comments about the article (in future will support markdown formatting)
+      required:
+        - name
+        - uri
+        - groupId
+        - notes


### PR DESCRIPTION
- Create openapi.yml and add some skeleton
- Add openapi-generator and provide some configuration
- Add basic operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced REST API endpoints for managing groups and articles (create, retrieve, list, update) with standardized JSON request/response schemas and error formats.

* **Chores**
  * Added an OpenAPI specification and automated API code-generation into the build, plus required runtime libraries so generated API models and interfaces are compiled and available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->